### PR TITLE
Material optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Includes
 include_directories(Includes)
+include_directories(Resources)
 include_directories(Libraries)
 include_directories(Libraries/glad)
 include_directories(Libraries/glm)

--- a/Includes/GL3/Scene.hpp
+++ b/Includes/GL3/Scene.hpp
@@ -38,6 +38,7 @@ namespace GL3 {
 		DebugUtils _debug;
 		GLuint _vao{ 0 }, _ebo{ 0 };
 		GLuint _matrixBuffer{ 0 };
+		GLuint _materialBuffer{ 0 };
 	};
 
 };

--- a/Resources/shaders/gltf.glsl
+++ b/Resources/shaders/gltf.glsl
@@ -1,29 +1,31 @@
 struct GltfShadeMaterial
 {
-	int shadingModel;  // 0: metallic-roughness, 1: specular-glossiness
-
 	// PbrMetallicRoughness
-	vec4  pbrBaseColorFactor;
-	int   pbrBaseColorTexture;
-	float pbrMetallicFactor;
-	float pbrRoughnessFactor;
-	int   pbrMetallicRoughnessTexture;
+	vec4  pbrBaseColorFactor; //16
+
+	int   pbrBaseColorTexture; //20
+	float pbrMetallicFactor; //24
+	float pbrRoughnessFactor; //28 
+	int   pbrMetallicRoughnessTexture; //32
 
 	// KHR_materials_pbrSpecularGlossiness
-	vec4  khrDiffuseFactor;
-	int   khrDiffuseTexture;
-	vec3  khrSpecularFactor;
-	float khrGlossinessFactor;
-	int   khrSpecularGlossinessTexture;
+	vec4  khrDiffuseFactor; //48
 
-	int   emissiveTexture;
-	vec3  emissiveFactor;
-	int   alphaMode;
-	float alphaCutoff;
-	int   doubleSided;
+	vec3  khrSpecularFactor; //60
+	int   khrDiffuseTexture; //64
+	float khrGlossinessFactor; //68
+	int   khrSpecularGlossinessTexture; //72
 
-	int   normalTexture;
-	float normalTextureScale;
-	int   occlusionTexture;
-	float occlusionTextureStrength;
+	int   emissiveTexture; //76
+	int   alphaMode; //80
+	vec3  emissiveFactor; //92
+	float alphaCutoff; // 96
+	int   doubleSided; //100
+
+	int   normalTexture; //104
+	float normalTextureScale; //108
+	int   occlusionTexture; //112
+	float occlusionTextureStrength; //116
+	int shadingModel;  // 120, 0: metallic-roughness, 1: specular-glossiness 
+	int padding[2];
 };

--- a/Resources/shaders/output.glsl
+++ b/Resources/shaders/output.glsl
@@ -33,14 +33,20 @@ layout(std140, binding = 1) uniform UBOScene
 	float envIntensity;	 // 40
 } uboScene;
 
+#include gltf.glsl
+layout(std430, binding = 3) readonly buffer UBOMaterial
+{
+	GltfShadeMaterial materials[];
+};
+
 #define MAX_TEXTURES 20
 layout ( binding = 0 ) uniform samplerCube samplerIrradiance;
 layout ( binding = 1 ) uniform sampler2D samplerBRDFLUT;
 layout ( binding = 2 ) uniform samplerCube prefilteredMap;
 layout ( binding = 3 ) uniform sampler2D textures[MAX_TEXTURES];
 
-#include gltf.glsl
-uniform GltfShadeMaterial material;
+uniform int materialIdx = 0;
+
 #include tonemapping.glsl
 #include utils.glsl
 #include pbr.glsl
@@ -79,6 +85,8 @@ void main()
 	vec3 f0						= vec3(0.04);
 	float perceptualRoughness;
 	float metallic;
+
+	GltfShadeMaterial material = materials[materialIdx];
 
 	if (material.shadingModel == PBR_METALLIC_ROUGHNESS_MODEL)
 	{


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24654975/119596970-1cb5c100-be1b-11eb-8d56-35b9c6b3b420.png)

Sending all material attributes as uniform varaible for every frame is quite expensive. 
I modified GltfShadeMaterial structure alignment for fitting to std430 layout and pass them shader storage block object. With new materialIdx uniform variable, indexing ssbo materials in rendering time.

After optimization, the event scrubber above quite improved compared with before